### PR TITLE
Change base docker image so ECR publishes work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/Clever/gearmand
     docker:
-    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+    - image: circleci/buildpack-deps:18.04
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results


### PR DESCRIPTION
For whatever reason ECR (AWS's version of docker hub) publish doesn't work with the `build-image:ubuntu-14.04-XXL-upstart-1189-5614f37` base image, so it's been updated to a newer one.  This should also speed up the build.